### PR TITLE
Add inference helper and Streamlit dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# DeepBP Transformer
+
+Questo repository contiene l'implementazione del modello **BPTransformer** per la ricostruzione di immagini a partire da sinogrammi.
+
+## Dashboard interattiva
+
+È disponibile una piccola dashboard Streamlit per visualizzare sinogrammi, ricostruzioni intermedie e output finali del modello:
+
+```bash
+streamlit run tools/dashboard_app.py
+```
+
+La dashboard utilizza i percorsi definiti in `TrainConfig` (in `main.py`) per individuare dataset e checkpoint. Se nella cartella `work_dir` configurata sono presenti i file `best.pt` o `last.pt`, verranno proposti per il caricamento automatico dei pesi.
+
+Puoi selezionare un file sinogramma già presente nei percorsi configurati oppure caricare un nuovo file `.hdf5`. Il parsing dei dati riusa la logica del dataset (`HDF5Dataset`) e mostra sia il sinogramma normalizzato sia i risultati di back-projection e del ViT.
+
+Assicurati di installare le dipendenze necessarie (Streamlit, PyTorch, nibabel, h5py, matplotlib, ecc.) prima di avviare la dashboard.

--- a/dataset.py
+++ b/dataset.py
@@ -1,6 +1,9 @@
 import os
+from typing import Tuple
+
 import h5py
 import torch
+import torch.nn.functional as F
 import nibabel as nib
 from torch.utils.data import Dataset
 
@@ -14,6 +17,72 @@ def minmax_scale(x: torch.Tensor, vmin: float, vmax: float, eps: float = 1e-12) 
     """Scale to [0,1] with global min/max; safely handle zero-range."""
     rng = max(vmax - vmin, eps)
     return (x - vmin) / rng
+
+
+def pad_or_crop_sinogram(sinogram: torch.Tensor, target_shape: Tuple[int, int]) -> torch.Tensor:
+    """Pad/crop a 2D sinogram to the desired detector/time shape."""
+    target_H, target_W = target_shape
+    H, W = sinogram.shape
+
+    if W > target_W:
+        sinogram = sinogram[:, :target_W]
+    elif W < target_W:
+        pad_width = target_W - W
+        sinogram = F.pad(sinogram, (0, pad_width), mode='constant', value=0)
+
+    if H > target_H:
+        sinogram = sinogram[:target_H, :]
+    elif H < target_H:
+        pad_height = target_H - H
+        sinogram = F.pad(sinogram, (0, 0, 0, pad_height), mode='constant', value=0)
+
+    return sinogram
+
+
+def load_hdf5_sample(
+    input_path: str,
+    target_dir: str,
+    wavelength: str,
+    target_shape: Tuple[int, int],
+    sino_min: float,
+    sino_max: float,
+    img_min: float,
+    img_max: float,
+    apply_normalization: bool = True,
+    require_target: bool = True,
+):
+    """Load a single sinogram/target pair applying the dataset preprocessing pipeline."""
+    with h5py.File(input_path, 'r') as f:
+        sinogram = torch.tensor(
+            f['simulations']['time_series_data'][str(wavelength)][()],
+            dtype=torch.float32
+        )
+
+    sinogram = pad_or_crop_sinogram(sinogram, target_shape).unsqueeze(0)
+
+    fname = os.path.basename(input_path).replace(
+        ".hdf5", f"_{wavelength}_rec_L1_shearlet.nii"
+    )
+    target_path = os.path.join(target_dir, fname)
+    target = None
+    if os.path.exists(target_path):
+        nifti = nib.load(target_path)
+        target_np = nifti.get_fdata().astype('float32')
+        if target_np.ndim == 2:
+            target = torch.tensor(target_np).unsqueeze(0)
+        else:
+            target = torch.tensor(target_np)
+    elif require_target:
+        raise FileNotFoundError(f"Target file not found: {target_path}")
+
+    sinogram = torch.flip(sinogram, dims=[1])
+
+    if apply_normalization:
+        sinogram = minmax_scale(sinogram, sino_min, sino_max)
+        if target is not None:
+            target = minmax_scale(target, img_min, img_max)
+
+    return sinogram, target
 
 class HDF5Dataset(Dataset):
     def __init__(self, input_dir, target_dir, sino_min: float, sino_max: float, img_min: float, img_max: float, split='train', wavelength=800, target_shape=(128, 1640)):
@@ -33,51 +102,19 @@ class HDF5Dataset(Dataset):
     def __len__(self):
         return len(self.file_list)
 
-    def _pad_or_crop(self, sinogram):
-        target_H, target_W = self.target_shape
-        H, W = sinogram.shape
-
-        if W > target_W:
-            sinogram = sinogram[:, :target_W]
-        elif W < target_W:
-            pad_width = target_W - W
-            sinogram = torch.nn.functional.pad(sinogram, (0, pad_width), mode='constant', value=0)
-
-        if H > target_H:
-            sinogram = sinogram[:target_H, :]
-        elif H < target_H:
-            pad_height = target_H - H
-            sinogram = torch.nn.functional.pad(sinogram, (0, 0, 0, pad_height), mode='constant', value=0)
-
-        return sinogram
-
     def __getitem__(self, idx):
         input_path = self.file_list[idx]
-
-        # === Leggi sinogramma HDF5 ===
-        with h5py.File(input_path, 'r') as f:
-            sinogram = torch.tensor(
-                f['simulations']['time_series_data'][self.wavelength][()],
-                dtype=torch.float32
-            )
-        sinogram = self._pad_or_crop(sinogram).unsqueeze(0)  # (1, 128, 1640)
-
-        # === Costruisci path per il target .nii ===
-        fname = os.path.basename(input_path).replace(".hdf5", f"_{self.wavelength}_rec_L1_shearlet.nii")
-        target_path = os.path.join(self.target_dir, fname)
-
-        # === Leggi target .nii ===
-        nifti = nib.load(target_path)
-        target_np = nifti.get_fdata().astype('float32')
-        if target_np.ndim == 2:
-            target = torch.tensor(target_np).unsqueeze(0)
-        else:
-            target = torch.tensor(target_np)
-
-        # Flip verticale (asse 0: detector elements) o orizzontale (asse 1: time samples)
-        sinogram = torch.flip(sinogram, dims=[1]) # flip detector axis
-
-        sinogram = minmax_scale(sinogram, self.smin, self.smax)
-        target = minmax_scale(target,  self.imin, self.imax)
+        sinogram, target = load_hdf5_sample(
+            input_path=input_path,
+            target_dir=self.target_dir,
+            wavelength=self.wavelength,
+            target_shape=self.target_shape,
+            sino_min=self.smin,
+            sino_max=self.smax,
+            img_min=self.imin,
+            img_max=self.imax,
+            apply_normalization=True,
+            require_target=True,
+        )
 
         return sinogram, target

--- a/tools/dashboard_app.py
+++ b/tools/dashboard_app.py
@@ -1,0 +1,159 @@
+"""Streamlit dashboard per esplorare il modello BPTransformer."""
+import os
+import tempfile
+from typing import List, Optional, Tuple
+
+import matplotlib.pyplot as plt
+import numpy as np
+import streamlit as st
+import torch
+
+from dataset import load_hdf5_sample, minmax_scale
+from main import (
+    TrainConfig,
+    create_model,
+    load_checkpoint,
+    run_inference_steps,
+)
+
+
+def list_hdf5_files(base_dir: str) -> List[str]:
+    """Return sorted list of .hdf5 files in a directory."""
+    if not os.path.isdir(base_dir):
+        return []
+    return sorted(f for f in os.listdir(base_dir) if f.endswith(".hdf5"))
+
+
+def tensor_to_numpy(t: torch.Tensor) -> np.ndarray:
+    return t.detach().cpu().squeeze().numpy()
+
+
+def plot_outputs(images: List[Tuple[str, np.ndarray]], sinogram: bool = False):
+    cols = len(images)
+    fig, axes = plt.subplots(1, cols, figsize=(4 * cols, 4))
+    if cols == 1:
+        axes = [axes]
+
+    for ax, (title, data) in zip(axes, images):
+        cmap = "magma" if "Sinogramma" in title else "gray"
+        ax.imshow(data, cmap=cmap, aspect="auto" if sinogram and "Sinogramma" in title else None)
+        ax.set_title(title)
+        ax.axis("off")
+    plt.tight_layout()
+    st.pyplot(fig)
+    plt.close(fig)
+
+
+def main():
+    st.set_page_config(page_title="BPTransformer Dashboard", layout="wide")
+    st.title("Dashboard BPTransformer")
+
+    cfg = TrainConfig()
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    st.sidebar.write(f"Dispositivo: {device}")
+
+    work_dir = cfg.work_dir
+    ckpts = [name for name in ("best.pt", "last.pt") if os.path.exists(os.path.join(work_dir, name))]
+
+    model = create_model(cfg, device)
+    selected_ckpt: Optional[str] = None
+    if ckpts:
+        selected_ckpt = st.sidebar.selectbox("Checkpoint", ckpts, index=0)
+        if selected_ckpt:
+            try:
+                load_checkpoint(model, cfg, selected_ckpt, map_location=device)
+                st.sidebar.success(f"Caricato {selected_ckpt}")
+            except FileNotFoundError as exc:
+                st.sidebar.error(str(exc))
+    else:
+        st.sidebar.warning(
+            "Nessun checkpoint trovato. Verranno usati pesi random inizializzati."
+        )
+
+    input_root = os.path.join(cfg.data_root, cfg.sino_dir)
+    target_root = os.path.join(cfg.data_root, cfg.recs_dir)
+    splits = [d for d in sorted(os.listdir(input_root)) if os.path.isdir(os.path.join(input_root, d))] if os.path.isdir(input_root) else []
+
+    st.header("Selezione del file")
+    selected_split = None
+    selected_file = None
+    if splits:
+        selected_split = st.selectbox("Split disponibile", splits)
+        split_dir = os.path.join(input_root, selected_split)
+        files = list_hdf5_files(split_dir)
+        if files:
+            selected_file = st.selectbox("File dal dataset", files)
+        else:
+            st.info("Nessun file .hdf5 trovato nello split selezionato.")
+    else:
+        st.info("Cartella dei sinogrammi non trovata o vuota: controlla TrainConfig.data_root.")
+
+    uploaded_file = st.file_uploader("Oppure carica un file .hdf5", type=["hdf5"])
+
+    sample_path = None
+    sample_label = None
+    temp_path = None
+    if selected_file and selected_split:
+        sample_path = os.path.join(input_root, selected_split, selected_file)
+        sample_label = f"{selected_split}/{selected_file}"
+    elif uploaded_file is not None:
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".hdf5") as tmp:
+            tmp.write(uploaded_file.read())
+            temp_path = tmp.name
+        sample_path = temp_path
+        sample_label = uploaded_file.name
+
+    if sample_path:
+        st.subheader("Risultati")
+        try:
+            sinogram_raw, target = load_hdf5_sample(
+                input_path=sample_path,
+                target_dir=target_root,
+                wavelength=str(cfg.wavelength),
+                target_shape=(cfg.n_det, cfg.n_t),
+                sino_min=cfg.sino_min,
+                sino_max=cfg.sino_max,
+                img_min=cfg.img_min,
+                img_max=cfg.img_max,
+                apply_normalization=False,
+                require_target=False,
+            )
+
+            sino_norm, bp_img, pred_img = run_inference_steps(
+                model,
+                sinogram_raw,
+                cfg,
+                device=device,
+                normalize=True,
+            )
+
+            sino_plot = tensor_to_numpy(sino_norm[0])
+            bp_plot = tensor_to_numpy(bp_img[0])
+            pred_plot = tensor_to_numpy(pred_img[0])
+
+            images = [
+                ("Sinogramma normalizzato", sino_plot),
+                ("BackProjection", bp_plot),
+                ("Predizione ViT", pred_plot),
+            ]
+
+            if target is not None:
+                target_norm = minmax_scale(target, cfg.img_min, cfg.img_max)
+                images.append(("Target", tensor_to_numpy(target_norm)))
+            else:
+                st.info("Target non trovato per il file selezionato.")
+
+            st.caption(f"File: {sample_label}")
+            plot_outputs(images, sinogram=True)
+        except Exception as exc:
+            st.error(f"Errore durante l'elaborazione: {exc}")
+        finally:
+            if temp_path is not None and os.path.exists(temp_path):
+                os.unlink(temp_path)
+
+    else:
+        st.info("Seleziona o carica un file per avviare l'inferenza.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- expose reusable helpers to build the BPTransformer, load checkpoints, and run inference steps with the intermediate back-projection
- share the dataset parsing logic so it can be reused outside of training and add a Streamlit dashboard to inspect samples interactively
- document how to launch the dashboard from the repository root

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cbbd01f96083329f3680f51fe21ef5