### PR TITLE
Fix gather reshape for expanded detector indices

### DIFF
--- a/main.py
+++ b/main.py
@@ -176,8 +176,8 @@ class BackProjectionLinear(nn.Module):
             v_d  = ve[..., d]
 
             # Gather S[:, d, k] -> (B, ny, nx)
-            s0 = S[:, d, :].gather(dim=1, index=k0_d.view(B, -1)).view(B, self.geom.ny, self.geom.nx)
-            s1 = S[:, d, :].gather(dim=1, index=k1_d.view(B, -1)).view(B, self.geom.ny, self.geom.nx)
+            s0 = S[:, d, :].gather(dim=1, index=k0_d.reshape(B, -1)).reshape(B, self.geom.ny, self.geom.nx)
+            s1 = S[:, d, :].gather(dim=1, index=k1_d.reshape(B, -1)).reshape(B, self.geom.ny, self.geom.nx)
 
             # Linear interpolation
             sk = (one - a_d) * s0 + a_d * s1


### PR DESCRIPTION
## Summary
- replace `.view` with `.reshape` in the backprojection gather logic to handle expanded detector indices safely
- reshape gathered detector samples without assuming contiguity before accumulation

## Testing
- python - <<'PY'
import torch
from main import LinearProbeGeom, build_backproj_lut, BackProjectionLinear

device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
geom = LinearProbeGeom(
    n_det=4,
    pitch_m=0.0003,
    t0_s=0.0,
    dt_s=1e-7,
    n_t=32,
    c_m_s=1500.0,
    x0_m=0.0,
    y0_m=0.0,
    dx_m=0.0005,
    dy_m=0.0005,
    nx=4,
    ny=4,
    array_x0_m=0.0,
    array_y_m=0.0,
)
lut = build_backproj_lut(geom, device=device)
bp = BackProjectionLinear(geom, lut).to(device)

sino = torch.randn(2, 1, geom.n_det, geom.n_t, device=device)
with torch.no_grad():
    out = bp(sino)
print('Output shape:', out.shape)
PY

------
https://chatgpt.com/codex/tasks/task_e_68cbdd1f4cdc8332bb6b4ea6492f78fb