### PR TITLE
Add configurable unrolled BP Transformer variant

### DIFF
--- a/tools/dashboard_app.py
+++ b/tools/dashboard_app.py
@@ -125,7 +125,7 @@ def main():
                 require_target=False,
             )
 
-            sino_norm, bp_img, pred_img = run_inference_steps(
+            sino_norm, bp_img, pred_img, intermediates = run_inference_steps(
                 model,
                 sinogram_raw,
                 cfg,


### PR DESCRIPTION
## Summary
- extend `TrainConfig` to cover model variant selection, unrolled settings, data-consistency weighting and apodization training
- introduce an `UnrolledBPTransformer` that runs iterative BP/FP refinement with a shared ViT block and exposes intermediate images
- adapt model creation, training, validation and inference utilities (including the dashboard) to the new forward signature and optimizer setup

## Testing
- python -m compileall main.py tools/dashboard_app.py

------
https://chatgpt.com/codex/tasks/task_e_68cbe7301e508332a4283e9d4d2590d9