### PR TITLE
Fix fold weight reconstruction parameters

### DIFF
--- a/main.py
+++ b/main.py
@@ -472,7 +472,10 @@ class ViTRefiner(nn.Module):
             weight = F.fold(
                 F.unfold(ones, kernel_size=self.patch_size, stride=stride),
                 output_size=shape,
+                kernel_size=self.patch_size,
+                stride=stride,
             )
+            weight = weight.to(device=device, dtype=dtype)
             self.fold_weight = weight
             self._fold_weight_shape = shape
             self._fold_weight_stride = stride


### PR DESCRIPTION
## Summary
- add the missing `kernel_size` and `stride` arguments when folding cached overlap weights in `_get_fold_weight`
- ensure the cached `fold_weight` tensor is stored on the requested device and dtype when rebuilt

## Testing
- python main.py *(interrupted with Ctrl+C after verifying the TypeError no longer occurs)*

------
https://chatgpt.com/codex/tasks/task_e_68cd1c8b75e083328c93e0eeac93e062