### PR TITLE
Rename backprojection components to DelayAndSum

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DeepBP Transformer
 
-Questo repository contiene l'implementazione del modello **BPTransformer** per la ricostruzione di immagini a partire da sinogrammi.
+Questo repository contiene l'implementazione del modello **DelayAndSumTransformer** (precedentemente conosciuto come BPTransformer) per la ricostruzione di immagini a partire da sinogrammi.
 
 ## Dashboard interattiva
 
@@ -12,6 +12,6 @@ streamlit run tools/dashboard_app.py
 
 La dashboard utilizza i percorsi definiti in `TrainConfig` (in `main.py`) per individuare dataset e checkpoint. Se nella cartella `work_dir` configurata sono presenti i file `best.pt` o `last.pt`, verranno proposti per il caricamento automatico dei pesi.
 
-Puoi selezionare un file sinogramma già presente nei percorsi configurati oppure caricare un nuovo file `.hdf5`. Il parsing dei dati riusa la logica del dataset (`HDF5Dataset`) e mostra sia il sinogramma normalizzato sia i risultati di back-projection e del ViT.
+Puoi selezionare un file sinogramma già presente nei percorsi configurati oppure caricare un nuovo file `.hdf5`. Il parsing dei dati riusa la logica del dataset (`HDF5Dataset`) e mostra sia il sinogramma normalizzato sia la ricostruzione Delay-and-Sum e l'output del ViT.
 
 Assicurati di installare le dipendenze necessarie (Streamlit, PyTorch, nibabel, h5py, matplotlib, ecc.) prima di avviare la dashboard.

--- a/tools/dashboard_app.py
+++ b/tools/dashboard_app.py
@@ -1,4 +1,4 @@
-"""Streamlit dashboard per esplorare il modello BPTransformer."""
+"""Streamlit dashboard per esplorare il modello DelayAndSumTransformer."""
 import os
 import sys
 import tempfile
@@ -51,8 +51,8 @@ def plot_outputs(images: List[Tuple[str, np.ndarray]], sinogram: bool = False):
 
 
 def main():
-    st.set_page_config(page_title="BPTransformer Dashboard", layout="wide")
-    st.title("Dashboard BPTransformer")
+    st.set_page_config(page_title="DelayAndSumTransformer Dashboard", layout="wide")
+    st.title("Dashboard DelayAndSumTransformer")
 
     cfg = TrainConfig()
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -125,7 +125,7 @@ def main():
                 require_target=False,
             )
 
-            sino_norm, bp_img, pred_img, iter_imgs = run_inference_steps(
+            sino_norm, das_img, pred_img, iter_imgs = run_inference_steps(
                 model,
                 sinogram_raw,
                 cfg,
@@ -134,12 +134,12 @@ def main():
             )
 
             sino_plot = tensor_to_numpy(sino_norm[0])
-            bp_plot = tensor_to_numpy(bp_img[0])
+            das_plot = tensor_to_numpy(das_img[0])
             pred_plot = tensor_to_numpy(pred_img[0])
 
             images = [
                 ("Sinogramma normalizzato", sino_plot),
-                ("BackProjection", bp_plot),
+                ("Delay-and-Sum", das_plot),
                 ("Predizione ViTRefiner", pred_plot),
             ]
 
@@ -160,7 +160,7 @@ def main():
                     sample_tensor = step_tensor[0] if step_tensor.dim() > 0 else step_tensor
                     iter_arrays.append(tensor_to_numpy(sample_tensor))
                     if idx == 0:
-                        label = f"Step {idx} (BP)"
+                        label = f"Step {idx} (DAS)"
                     elif idx == total_steps - 1:
                         label = f"Step {idx} (finale)"
                     else:


### PR DESCRIPTION
## Summary
- rename the backprojection LUT, beamformer module, and transformer wrappers to Delay-and-Sum terminology throughout the training code
- propagate the new DelayAndSum naming into the Streamlit dashboard and README so the UI and docs match the operator rename
- keep backward compatibility for the legacy `bp_transformer` variant string while defaulting configuration paths to the new DAS naming

## Testing
- python -m compileall main.py dataset.py tools/dashboard_app.py

------
https://chatgpt.com/codex/tasks/task_e_68cd2f7144f48332a539daa3bd1d5532