### PR TITLE
Fix cumtrapz index dtype

### DIFF
--- a/bp_MSOT_runner.py
+++ b/bp_MSOT_runner.py
@@ -66,7 +66,9 @@ class BackProjectionReconstructorTorch:
         x1 = torch.narrow(x, dim, 1, x.size(dim) - 1)
         x0 = torch.narrow(x, dim, 0, x.size(dim) - 1)
         mid = 0.5 * (x1 + x0) * dt
-        y0 = torch.zeros_like(torch.index_select(x, dim, torch.tensor([0], device=x.device)))
+        y0 = torch.zeros_like(
+            torch.index_select(x, dim, torch.tensor([0], device=x.device, dtype=torch.long))
+        )
         y = torch.cat([y0, torch.cumsum(mid, dim=dim)], dim=dim)
         return y
 


### PR DESCRIPTION
## Summary
- ensure `_cumtrapz_constant_dt` builds an integer index tensor before calling `torch.index_select`

## Testing
- `python - <<'PY' ...` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch --index-url https://download.pytorch.org/whl/cpu` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68d14b2bb51c8332a83f2246af0ba4e6