### PR TITLE
Fix dtype mismatch during forward projection FFT computation

### DIFF
--- a/main.py
+++ b/main.py
@@ -487,7 +487,9 @@ class ForwardProjectionFk(nn.Module):
             -1j * (kx.view(-1, 1) * x_phase_coords.view(1, -1))
         ).to(dtype=complex_dtype)
         img_line_flat = img_line.reshape(B * ny, nx)
-        img_fft = torch.matmul(img_line_flat, phase_x.transpose(0, 1))
+        img_fft = torch.matmul(
+            img_line_flat.to(dtype=complex_dtype), phase_x.transpose(0, 1)
+        )
         img_fft = img_fft.view(B, ny, n_kx)
         dx = torch.as_tensor(self.geom.dx_m, device=device, dtype=working_dtype)
         img_fft = img_fft.to(dtype=complex_dtype) * dx.to(dtype=complex_dtype)


### PR DESCRIPTION
## Summary
- convert the flattened image tensor to the complex dtype before multiplying it with the complex phase factors in the forward projection

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68d168dd9fd88332bc984f668bfbf04c