### PR TITLE
Add static fk output normalization option

### DIFF
--- a/deepbp/config.py
+++ b/deepbp/config.py
@@ -36,6 +36,8 @@ class TrainConfig:
     fk_fft_pad: int = 0
     fk_window: Optional[str] = None
     fk_learnable_output_normalization: bool = False
+    fk_output_normalization_scale: Optional[float] = None
+    fk_output_normalization_shift: Optional[float] = None
 
     # ViT refiner
     vit_patch: int = 16
@@ -125,6 +127,8 @@ def build_projection_operators(
             fft_pad=fft_pad,
             window=cfg.fk_window,
             learnable_output_normalization=cfg.fk_learnable_output_normalization,
+            static_output_scale=cfg.fk_output_normalization_scale,
+            static_output_shift=cfg.fk_output_normalization_shift,
         )
         forward_op = ForwardProjectionFk(beamformer)
     else:


### PR DESCRIPTION
## Summary
- add configuration knobs for static f-k output normalization scale and shift
- propagate the parameters to FkMigrationLinear and apply them when learnable normalization is disabled

## Testing
- python -m compileall deepbp

------
https://chatgpt.com/codex/tasks/task_e_68d5474d7ffc8332ae9d0785c54e0bac