### PR TITLE
Enable training resume support with checkpoint state restoration

### DIFF
--- a/deepbp/config.py
+++ b/deepbp/config.py
@@ -77,6 +77,8 @@ class TrainConfig:
     val_intermediate_indices: Optional[List[int]] = field(
         default_factory=lambda: [0, 1, 2, 3, 4]
     )
+    resume_training: bool = False
+    resume_checkpoint: Optional[str] = None
 
 
 def build_geometry(cfg: TrainConfig) -> LinearProbeGeom:


### PR DESCRIPTION
## Summary
- add configuration flags to control training resume behavior and checkpoint selection
- load checkpoints when resuming to restore model, optimizer, scheduler, and metrics without clearing the work directory
- persist optimizer, scheduler, and tracking metrics in best/last checkpoints to support seamless restarts

## Testing
- python -m compileall deepbp/config.py main.py

------
https://chatgpt.com/codex/tasks/task_e_68d65c3f34a08332b4edea6fab51e961