### PR TITLE
Add configurable FK normalization parameter initialization

### DIFF
--- a/deepbp/config.py
+++ b/deepbp/config.py
@@ -38,6 +38,8 @@ class TrainConfig:
     fk_learnable_output_normalization: bool = False
     fk_output_normalization_scale: Optional[float] = 100
     fk_output_normalization_shift: Optional[float] = 0
+    fk_output_norm_scale_init: Optional[float] = None
+    fk_output_norm_shift_init: Optional[float] = None
 
     # ViT refiner
     vit_patch: int = 16
@@ -131,6 +133,8 @@ def build_projection_operators(
             learnable_output_normalization=cfg.fk_learnable_output_normalization,
             static_output_scale=cfg.fk_output_normalization_scale,
             static_output_shift=cfg.fk_output_normalization_shift,
+            output_norm_scale_init=cfg.fk_output_norm_scale_init,
+            output_norm_shift_init=cfg.fk_output_norm_shift_init,
         )
         forward_op = ForwardProjectionFk(beamformer)
     else:


### PR DESCRIPTION
## Summary
- extend the training configuration to expose optional FK output normalization initialization values
- initialize learnable FK migration normalization parameters from the provided targets using softplus inversion
- add a regression test covering the new initialization path

## Testing
- pytest tests/test_fk_normalization.py

------
https://chatgpt.com/codex/tasks/task_e_68d6a64b10a88332929edcaf4a574d5b