### PR TITLE
Allow signed FK residual corrections

### DIFF
--- a/deepbp/models/transformer.py
+++ b/deepbp/models/transformer.py
@@ -74,6 +74,7 @@ class UnrolledDelayAndSumTransformer(nn.Module):
                 sino_residual,
                 update_cache=False,
                 pre_normalized=True,
+                return_magnitude=False,
             )
             xi = xi + weight * correction
             xi = self.vit(xi)


### PR DESCRIPTION
## Summary
- add a `return_magnitude` option to `FkMigrationLinear.forward` to expose signed residuals when needed
- use the signed path during the unrolled transformer's residual correction updates
- add a regression test ensuring residual beamforming can emit both positive and negative corrections

## Testing
- pytest tests/test_unrolled_transformer_residual.py

------
https://chatgpt.com/codex/tasks/task_e_68daac55701083329c32475689d1c565