### PR TITLE
Add configurable FK beamformer output components

### DIFF
--- a/deepbp/beamformers/fk.py
+++ b/deepbp/beamformers/fk.py
@@ -1,7 +1,7 @@
 """Frequency-wavenumber migration operators."""
 import math
 import warnings
-from typing import List, Optional, Tuple
+from typing import Iterable, List, Optional, Sequence, Tuple
 
 import numpy as np
 import torch
@@ -12,7 +12,33 @@ from ..geometry import LinearProbeGeom
 
 
 class FkMigrationLinear(nn.Module):
-    """Frequency-wavenumber migration for linear probe acquisitions."""
+    """Frequency-wavenumber migration for linear probe acquisitions.
+
+    Parameters
+    ----------
+    geom:
+        Acquisition geometry definition.
+    trainable_apodization:
+        Whether to learn per-detector apodization weights.
+    per_channel_apodization:
+        Whether to provide separate apodization weights per input channel.
+    fft_pad:
+        Number of samples used to zero-pad the temporal FFT.
+    window:
+        Optional temporal windowing function name.
+    learnable_output_normalization:
+        Enable a learnable sigmoid-based post-processing for magnitude outputs.
+    static_output_scale/static_output_shift:
+        Fixed affine post-processing parameters for magnitude outputs.
+    output_norm_scale_init/output_norm_shift_init:
+        Optional initialization for the learnable normalization parameters.
+    output_components:
+        Tuple describing which complex-valued components to return by default.
+        Supported entries are ``"magnitude"``, ``"real"``, and ``"imag"``.
+        When the forward pass requests magnitude channels their normalization is
+        applied using either the learnable or static configuration. Real and
+        imaginary channels are never normalized automatically.
+    """
 
     def __init__(
         self,
@@ -26,6 +52,7 @@ class FkMigrationLinear(nn.Module):
         static_output_shift: Optional[float] = None,
         output_norm_scale_init: Optional[float] = None,
         output_norm_shift_init: Optional[float] = None,
+        output_components: Optional[Iterable[str]] = None,
     ) -> None:
         super().__init__()
         self.geom = geom
@@ -34,6 +61,11 @@ class FkMigrationLinear(nn.Module):
         self.learnable_output_normalization = learnable_output_normalization
         self.static_output_scale = static_output_scale
         self.static_output_shift = static_output_shift
+
+        if output_components is None:
+            output_components = ("magnitude",)
+        self.output_components = self._validate_components(output_components)
+        self.default_output_channels = len(self.output_components)
 
         if self.learnable_output_normalization and (
             self.static_output_scale is not None or self.static_output_shift is not None
@@ -124,6 +156,22 @@ class FkMigrationLinear(nn.Module):
             self.output_shift = nn.Parameter(torch.tensor(shift_value, dtype=torch.float32))
 
         self._cached_norm_stats: Optional[Tuple[torch.Tensor, torch.Tensor]] = None
+
+    @staticmethod
+    def _validate_components(components: Iterable[str]) -> Tuple[str, ...]:
+        valid = {"magnitude", "real", "imag"}
+        try:
+            component_list = tuple(str(comp).lower() for comp in components)
+        except TypeError as exc:  # pragma: no cover - defensive
+            raise TypeError("output_components must be an iterable of strings") from exc
+        if not component_list:
+            raise ValueError("output_components must contain at least one entry")
+        invalid = [comp for comp in component_list if comp not in valid]
+        if invalid:
+            raise ValueError(
+                "Unsupported components requested for FkMigrationLinear: " + ", ".join(invalid)
+            )
+        return component_list
 
     @staticmethod
     def _build_time_window(window: Optional[str], length: int) -> torch.Tensor:
@@ -245,6 +293,7 @@ class FkMigrationLinear(nn.Module):
         update_cache: bool = True,
         pre_normalized: bool = False,
         return_magnitude: bool = True,
+        return_components: Optional[Sequence[str]] = None,
     ) -> torch.Tensor:
         """Apply f-k migration to a sinogram of shape ``[B, C, n_det, n_t]``.
 
@@ -269,6 +318,12 @@ class FkMigrationLinear(nn.Module):
             returned. Setting this to ``False`` returns the signed real component
             of the image, which is useful for residual corrections where the
             contribution may be positive or negative.
+        return_components:
+            Optional override for the components requested from the complex
+            image. When provided, the resulting tensor concatenates the requested
+            components along the channel dimension in the order specified. The
+            ``return_magnitude=False`` shorthand is equivalent to requesting only
+            the real component.
         """
 
         B, C, n_det, n_t = sino.shape
@@ -320,37 +375,49 @@ class FkMigrationLinear(nn.Module):
         img_complex = torch.matmul(band, phase_x)
         img_complex = img_complex.view(B, C, self.geom.ny, self.geom.nx)
 
-        if return_magnitude:
-            img_out = img_complex.abs()
-        else:
-            img_out = img_complex.real
-        img_out = img_out.to(dtype)
-
         apod_sum = torch.clamp(apod.sum(dim=-1, keepdim=True), min=eps)
         norm = apod_sum.view(1, C, 1, 1) * freq_weight_sum.reshape(1, 1, 1, 1)
-        img_out = img_out / norm
+        img_complex = img_complex / norm.to(dtype=img_complex.dtype)
 
-        # print(f"Min: {img_out.min()}, Max: {img_out.max()}")
-
-        if return_magnitude:
-            if self.learnable_output_normalization:
-                scale = F.softplus(self.output_scale).to(dtype=img_out.dtype, device=img_out.device)
-                shift = self.output_shift.to(dtype=img_out.dtype, device=img_out.device)
-                img_out = torch.sigmoid(scale * (img_out - shift))
+        if return_components is None:
+            if return_magnitude:
+                components = self.output_components
             else:
-                if self.static_output_shift is not None:
-                    shift = torch.as_tensor(
-                        self.static_output_shift, dtype=img_out.dtype, device=img_out.device
-                    )
-                    img_out = img_out - shift
-                if self.static_output_scale is not None:
-                    scale = torch.as_tensor(
-                        self.static_output_scale, dtype=img_out.dtype, device=img_out.device
-                    )
-                    if torch.any(scale == 0):
-                        raise ValueError("static_output_scale must be non-zero for normalization")
-                    img_out = img_out / scale
+                components = ("real",)
+        else:
+            components = self._validate_components(return_components)
 
+        outputs: List[torch.Tensor] = []
+        for component in components:
+            if component == "magnitude":
+                comp_tensor = img_complex.abs().to(dtype)
+                if self.learnable_output_normalization:
+                    scale = F.softplus(self.output_scale).to(dtype=comp_tensor.dtype, device=comp_tensor.device)
+                    shift = self.output_shift.to(dtype=comp_tensor.dtype, device=comp_tensor.device)
+                    comp_tensor = torch.sigmoid(scale * (comp_tensor - shift))
+                else:
+                    if self.static_output_shift is not None:
+                        shift = torch.as_tensor(
+                            self.static_output_shift, dtype=comp_tensor.dtype, device=comp_tensor.device
+                        )
+                        comp_tensor = comp_tensor - shift
+                    if self.static_output_scale is not None:
+                        scale = torch.as_tensor(
+                            self.static_output_scale, dtype=comp_tensor.dtype, device=comp_tensor.device
+                        )
+                        if torch.any(scale == 0):
+                            raise ValueError("static_output_scale must be non-zero for normalization")
+                        comp_tensor = comp_tensor / scale
+            elif component == "real":
+                comp_tensor = img_complex.real.to(dtype)
+            else:  # component == "imag"
+                comp_tensor = img_complex.imag.to(dtype)
+            outputs.append(comp_tensor)
+
+        if outputs:
+            img_out = torch.cat(outputs, dim=1)
+        else:  # pragma: no cover - defensive
+            raise RuntimeError("No components produced in FkMigrationLinear.forward")
         return img_out
 
 

--- a/tests/test_fk_normalization.py
+++ b/tests/test_fk_normalization.py
@@ -123,3 +123,33 @@ def test_large_output_norm_scale_init_is_finite() -> None:
     assert torch.isfinite(stored_scale).all()
     assert torch.isfinite(recovered_scale).all()
     assert torch.allclose(recovered_scale, desired_scale, rtol=1e-5, atol=1e-5)
+
+
+def test_forward_multiple_components_returns_expected_channels() -> None:
+    geom = _make_geometry()
+    migration = FkMigrationLinear(geom)
+
+    sino = torch.randn(1, 2, geom.n_det, geom.n_t)
+
+    multi = migration.forward(sino, return_components=("real", "imag"))
+    assert multi.shape[1] == 2 * sino.shape[1]
+
+    stats = migration._cached_norm_stats
+    assert stats is not None
+
+    real_only = migration.forward(
+        sino,
+        stats=stats,
+        update_cache=False,
+        return_magnitude=False,
+    )
+    imag_only = migration.forward(
+        sino,
+        stats=stats,
+        update_cache=False,
+        return_components=("imag",),
+    )
+
+    real_part, imag_part = multi.chunk(2, dim=1)
+    assert torch.allclose(real_part, real_only)
+    assert torch.allclose(imag_part, imag_only)


### PR DESCRIPTION
## Summary
- add configuration for default FK output components and cache their derived channel count
- extend the migration forward pass to concatenate requested components and normalize magnitude channels only
- add coverage to ensure multiple requested components return the expected ordering

## Testing
- pytest tests/test_fk_normalization.py

------
https://chatgpt.com/codex/tasks/task_e_68dd142733148332bc28562881eccec0