### PR TITLE
Allow FK forward projection for multi-channel inputs

### DIFF
--- a/deepbp/beamformers/fk.py
+++ b/deepbp/beamformers/fk.py
@@ -439,10 +439,16 @@ class ForwardProjectionFk(nn.Module):
         return self.migration.get_apodization(dtype, device, channels)
 
     def forward(self, img: torch.Tensor) -> torch.Tensor:
-        """Project an image into the sinogram domain using the f-k model."""
+        """Project an image into the sinogram domain using the f-k model.
+
+        Notes
+        -----
+        Only the first channel of ``img`` is used for the physical projection.
+        Any additional channels are propagated unchanged through data-consistency
+        operations performed outside this module.
+        """
 
         B, C, ny, nx = img.shape
-        assert C == 1, "Expect image with a single channel."
         assert ny == self.geom.ny and nx == self.geom.nx, "Image dims mismatch geometry."
 
         if (


### PR DESCRIPTION
## Summary
- relax ForwardProjectionFk to accept multi-channel images while documenting that only the first channel is physically projected
- keep the existing magnitude-channel slice so downstream consistency steps operate on the primary component
- add a regression test ensuring multi-channel inputs run and gradients flow through the first channel

## Testing
- pytest tests/test_unrolled_transformer_residual.py

------
https://chatgpt.com/codex/tasks/task_e_68dd1fdde83c83328cfd70f8e479760f