### PR TITLE
Handle multichannel beamformer outputs

### DIFF
--- a/deepbp/inference.py
+++ b/deepbp/inference.py
@@ -7,14 +7,50 @@ from dataset import minmax_scale
 from .config import TrainConfig
 
 
+def _extract_canonical_initial(
+    beamformer_output: torch.Tensor, reference: Optional[torch.Tensor] = None
+) -> torch.Tensor:
+    """Return a view containing the first channel/batch element for display."""
+
+    x = beamformer_output
+    if reference is not None and reference.dim() >= 1:
+        ref_batch = reference.shape[0]
+    else:
+        ref_batch = None
+
+    if x.dim() == 4:
+        # (B, C, H, W)
+        return x[:, :1, ...]
+
+    if x.dim() == 3:
+        # Ambiguous: could be (B, H, W) or (C, H, W) with B == 1.
+        if ref_batch is not None and x.shape[0] == ref_batch:
+            return x.unsqueeze(1)
+        return x[:1, ...].unsqueeze(0)
+
+    if x.dim() == 2:
+        return x.unsqueeze(0).unsqueeze(0)
+
+    if x.dim() == 1:
+        return x.unsqueeze(0).unsqueeze(-1)
+
+    return x
+
+
 def run_inference_steps(
     model: torch.nn.Module,
     sinogram: torch.Tensor,
     cfg: TrainConfig,
     device: Optional[torch.device] = None,
     normalize: bool = True,
-) -> Tuple[torch.Tensor, Optional[torch.Tensor], torch.Tensor, Optional[List[torch.Tensor]]]:
-    """Return normalized sinogram, initial image, final output and intermediate steps."""
+) -> Tuple[
+    torch.Tensor,
+    Optional[torch.Tensor],
+    torch.Tensor,
+    Optional[List[torch.Tensor]],
+    Optional[torch.Tensor],
+]:
+    """Return normalized sinogram, initial image, final output, intermediates and beamformer stack."""
 
     if device is None:
         device = next(model.parameters()).device
@@ -38,8 +74,10 @@ def run_inference_steps(
         pred, beamformer_img, intermediates = model(sino_norm)
 
     iter_sequence: List[torch.Tensor] = []
+    canonical_initial: Optional[torch.Tensor] = None
     if beamformer_img is not None:
-        iter_sequence.append(beamformer_img)
+        canonical_initial = _extract_canonical_initial(beamformer_img, pred)
+        iter_sequence.append(canonical_initial)
 
     if intermediates is not None:
         if isinstance(intermediates, (list, tuple)):
@@ -52,11 +90,17 @@ def run_inference_steps(
 
     iter_imgs = [step.detach().cpu() for step in iter_sequence] if iter_sequence else None
 
-    beamformer_cpu = beamformer_img.detach().cpu() if beamformer_img is not None else None
+    beamformer_cpu = (
+        canonical_initial.detach().cpu() if canonical_initial is not None else None
+    )
+    beamformer_stack_cpu = (
+        beamformer_img.detach().cpu() if beamformer_img is not None else None
+    )
 
     return (
         sino_norm.detach().cpu(),
         beamformer_cpu,
         pred.detach().cpu(),
         iter_imgs,
+        beamformer_stack_cpu,
     )

--- a/deepbp/visualization.py
+++ b/deepbp/visualization.py
@@ -16,19 +16,20 @@ def save_side_by_side(
     vmax: Optional[float] = None,
     iter_steps: Optional[List[Tuple[int, torch.Tensor]]] = None,
 ) -> None:
-    """Save a side-by-side image [Initial | intermediates | Pred | GT]."""
+    """Save a side-by-side image [Initial | intermediates | Pred | GT].
+
+    When tensors contain multiple channels, the first channel is used for visualization.
+    """
 
     os.makedirs(os.path.dirname(out_path), exist_ok=True)
 
     def to_uint8(img: torch.Tensor) -> Image.Image:
         x = img.detach()
 
-        if x.dim() == 4 and x.shape[0] == 1 and x.shape[1] == 1:
-            x = x[0, 0]
-        elif x.dim() == 3 and x.shape[0] == 1:
+        while x.dim() > 2:
+            if x.size(0) == 0:
+                raise ValueError("Cannot visualize an empty tensor")
             x = x[0]
-        else:
-            x = x.squeeze()
 
         if x.dim() < 2:
             raise ValueError(f"Expected image-like tensor, got shape {tuple(img.shape)}")

--- a/tests/test_multichannel_support.py
+++ b/tests/test_multichannel_support.py
@@ -1,0 +1,138 @@
+"""Tests covering multi-channel beamformer outputs in inference and visualization."""
+
+import math
+from typing import Optional, Tuple
+
+import pytest
+
+Image = pytest.importorskip("PIL.Image")
+
+torch = pytest.importorskip("torch")
+nn = pytest.importorskip("torch.nn")
+
+from deepbp.config import TrainConfig
+from deepbp.inference import run_inference_steps
+from deepbp.visualization import save_side_by_side
+
+
+class _DummyModel(nn.Module):
+    def __init__(self, output_shape: Tuple[int, int]):
+        super().__init__()
+        self.param = nn.Parameter(torch.zeros(1))
+        self._output_shape = output_shape
+
+    def forward(
+        self, sino: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+        batch = sino.shape[0]
+        h, w = self._output_shape
+        device = sino.device
+        dtype = sino.dtype
+
+        base = torch.linspace(0.0, 1.0, steps=h * w, device=device, dtype=dtype)
+        base = base.view(1, 1, h, w).repeat(batch, 1, 1, 1)
+        beamformer = torch.stack(
+            (
+                base.squeeze(1),
+                torch.ones_like(base.squeeze(1)) * 0.5,
+            ),
+            dim=1,
+        )
+        pred = base * 0.25
+        return pred, beamformer, None
+
+
+def _expected_uint8(channel: torch.Tensor) -> torch.Tensor:
+    x = channel.clone()
+    finite_mask = torch.isfinite(x)
+    if finite_mask.any():
+        valid = x[finite_mask]
+        local_min, local_max = torch.aminmax(valid)
+    else:
+        local_min = torch.tensor(0.0, dtype=x.dtype)
+        local_max = torch.tensor(1.0, dtype=x.dtype)
+
+    lo = float(local_min.item())
+    hi = float(local_max.item())
+    if not math.isfinite(lo):
+        lo = 0.0
+    if not math.isfinite(hi):
+        hi = lo
+    if hi - lo < 1e-6:
+        hi = lo + 1e-6
+
+    x = torch.nan_to_num(x, nan=lo, posinf=hi, neginf=lo)
+    x = (x - lo) / (hi - lo)
+    x = x.clamp(0.0, 1.0)
+    return (x * 255.0).round().to(dtype=torch.uint8)
+
+
+def test_run_inference_steps_returns_canonical_initial_and_stack():
+    model = _DummyModel(output_shape=(3, 4))
+    cfg = TrainConfig()
+    sino = torch.randn(1, 1, 2, 2)
+
+    (
+        _,
+        initial_img,
+        pred,
+        iter_imgs,
+        beamformer_stack,
+    ) = run_inference_steps(model, sino, cfg, normalize=False)
+
+    assert initial_img is not None
+    assert beamformer_stack is not None
+    assert beamformer_stack.shape[1] == 2
+    assert initial_img.shape[1] == 1
+    assert torch.allclose(initial_img[:, 0], beamformer_stack[:, 0])
+    assert iter_imgs is not None
+    assert torch.allclose(iter_imgs[0], initial_img)
+    assert pred.shape[0] == sino.shape[0]
+
+
+def test_save_side_by_side_multichannel_uses_first_channel(tmp_path):
+    pred = torch.zeros(1, 1, 2, 2)
+    gt = torch.zeros(1, 1, 2, 2)
+    initial = torch.stack(
+        (
+            torch.tensor([[0.0, 1.0], [0.5, 0.75]], dtype=torch.float32),
+            torch.full((2, 2), 0.25, dtype=torch.float32),
+        ),
+        dim=0,
+    )
+    iter_tensor = torch.stack(
+        (
+            torch.tensor([[1.0, 0.0], [0.25, 0.5]], dtype=torch.float32),
+            torch.full((2, 2), -1.0, dtype=torch.float32),
+        ),
+        dim=0,
+    )
+
+    out_path = tmp_path / "viz.png"
+    save_side_by_side(
+        pred[0],
+        gt[0],
+        initial,
+        str(out_path),
+        iter_steps=[(1, iter_tensor)],
+    )
+
+    assert out_path.exists()
+
+    with Image.open(out_path) as img:
+        if hasattr(torch, "frombuffer"):
+            data = torch.frombuffer(img.tobytes(), dtype=torch.uint8)
+        else:
+            data = torch.tensor(list(img.getdata()), dtype=torch.uint8)
+        arr = data.view(img.height, img.width)
+
+    # We expect four panels: initial, intermediate, pred, gt.
+    panel_w = arr.shape[1] // 4
+    initial_panel = arr[:, :panel_w]
+    iter_panel = arr[:, panel_w : 2 * panel_w]
+
+    expected_initial = _expected_uint8(initial[0])
+    expected_iter = _expected_uint8(iter_tensor[0])
+
+    torch.testing.assert_close(initial_panel, expected_initial.cpu(), rtol=0, atol=0)
+    torch.testing.assert_close(iter_panel, expected_iter.cpu(), rtol=0, atol=0)

--- a/tools/dashboard_app.py
+++ b/tools/dashboard_app.py
@@ -261,7 +261,13 @@ def main():
                 require_target=False,
             )
 
-            sino_norm, initial_img, pred_img, iter_imgs = run_inference_steps(
+            (
+                sino_norm,
+                initial_img,
+                pred_img,
+                iter_imgs,
+                beamformer_stack,
+            ) = run_inference_steps(
                 model,
                 sinogram_raw,
                 cfg,
@@ -360,6 +366,12 @@ def main():
                 )
             else:
                 st.info("Il modello non restituisce step intermedi da visualizzare.")
+
+            if beamformer_stack is not None and beamformer_stack.shape[1] > 1:
+                st.info(
+                    "Il beamformer ha fornito più canali. È possibile ispezionare tutte le feature "
+                    "dalla variabile `beamformer_stack`."
+                )
         except Exception as exc:
             st.error(f"Errore durante l'elaborazione: {exc}")
         finally:


### PR DESCRIPTION
## Summary
- ensure inference surfaces both the first beamformer channel and the full feature stack
- make visualization utilities default to channel 0 when multiple channels are present
- add coverage to confirm validation/inference saving tolerates multi-channel beamformers

## Testing
- `pytest` *(skipped: dependencies such as torch/PIL are unavailable in CI)*

------
https://chatgpt.com/codex/tasks/task_e_68dd20656c0483328e00d64f5132d7b2