### PR TITLE
Add option to skip target normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,18 @@ La dashboard utilizza i percorsi definiti in `TrainConfig` (in `main.py`) per in
 Puoi selezionare un file sinogramma già presente nei percorsi configurati oppure caricare un nuovo file `.hdf5`. Il parsing dei dati riusa la logica del dataset (`HDF5Dataset`) e mostra sia il sinogramma normalizzato sia la ricostruzione Delay-and-Sum e l'output del ViT.
 
 Assicurati di installare le dipendenze necessarie (Streamlit, PyTorch, nibabel, h5py, matplotlib, ecc.) prima di avviare la dashboard.
+
+## Normalizzazione dei target
+
+Di default il dataset scala sinogrammi e immagini di riferimento nell'intervallo
+[0, 1] utilizzando le statistiche globali configurate (`sino_min/sino_max` e
+`img_min/img_max`). È ora possibile disattivare la normalizzazione delle sole
+immagini impostando `TrainConfig.normalize_targets = False`. In questo modo i
+target vengono restituiti nel loro range originale (ad esempio 0–320) mentre i
+sinogrammi continuano a essere normalizzati.
+
+Disattivare la normalizzazione modifica la scala della loss L1 (i valori
+risulteranno più grandi in proporzione al nuovo range) e dei pesi basati
+sull'intensità. Le soglie `weight_threshold` e `ssim_mask_threshold` operano
+sempre sui valori prodotti dal dataset: se si usano target non normalizzati è
+quindi consigliabile aggiornarle esplicitamente in base alle nuove unità.

--- a/deepbp/config.py
+++ b/deepbp/config.py
@@ -57,6 +57,7 @@ class TrainConfig:
     weight_threshold: Optional[float] = None
     ssim_mask_threshold: Optional[float] = 0.5
     ssim_mask_dilation: int = 0
+    normalize_targets: bool = True
 
     # Model variants
     model_variant: str = "unrolled"

--- a/main.py
+++ b/main.py
@@ -33,6 +33,7 @@ def build_dataloaders(cfg: TrainConfig) -> Tuple[DataLoader, DataLoader]:
             split="train",
             wavelength=cfg.wavelength,
             target_shape=(cfg.n_det, cfg.n_t),
+            normalize_targets=cfg.normalize_targets,
         )
 
         val_ds = HDF5Dataset(
@@ -45,6 +46,7 @@ def build_dataloaders(cfg: TrainConfig) -> Tuple[DataLoader, DataLoader]:
             split="val",
             wavelength=cfg.wavelength,
             target_shape=(cfg.n_det, cfg.n_t),
+            normalize_targets=cfg.normalize_targets,
         )
     elif dataset_type == "voc":
         train_ds = VOCDataset(
@@ -55,6 +57,7 @@ def build_dataloaders(cfg: TrainConfig) -> Tuple[DataLoader, DataLoader]:
             cfg.img_max,
             split="train",
             target_shape=(cfg.n_det, cfg.n_t),
+            normalize_targets=cfg.normalize_targets,
         )
 
         val_ds = VOCDataset(
@@ -65,6 +68,7 @@ def build_dataloaders(cfg: TrainConfig) -> Tuple[DataLoader, DataLoader]:
             cfg.img_max,
             split="val",
             target_shape=(cfg.n_det, cfg.n_t),
+            normalize_targets=cfg.normalize_targets,
         )
     else:
         supported = ("hdf5", "voc")


### PR DESCRIPTION
## Summary
- add dataset-level switches to optionally skip target normalization for HDF5 and VOC samples
- plumb a TrainConfig.normalize_targets flag through dataloader construction and document its effect on loss scaling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df8bd9ef98833290df3f97cdbed4d9