### PR TITLE
Add summary statistics to NIfTI metrics output

### DIFF
--- a/tools/nifti_metrics.py
+++ b/tools/nifti_metrics.py
@@ -129,6 +129,20 @@ def save_csv(results: Sequence[MetricResult], destination: Path) -> None:
         for res in results:
             writer.writerow([res.name, res.mse, res.mae, res.psnr, res.ssim])
 
+        summary = summarize_metrics(results)
+        writer.writerow([summary.name, summary.mse, summary.mae, summary.psnr, summary.ssim])
+
+
+def summarize_metrics(results: Sequence[MetricResult]) -> MetricResult:
+    summary = MetricResult(
+        name="summary",
+        mse=float(np.mean([res.mse for res in results])),
+        mae=float(np.mean([res.mae for res in results])),
+        psnr=float(np.mean([res.psnr for res in results])),
+        ssim=float(np.mean([res.ssim for res in results])),
+    )
+    return summary
+
 
 def main(
     predictions_dir: Path,
@@ -147,6 +161,9 @@ def main(
     print("file,mse,mae,psnr,ssim")
     for res in results:
         print(f"{res.name},{res.mse},{res.mae},{res.psnr},{res.ssim}")
+
+    summary = summarize_metrics(results)
+    print(f"{summary.name},{summary.mse},{summary.mae},{summary.psnr},{summary.ssim}")
 
     if csv_path is not None:
         save_csv(results, csv_path)


### PR DESCRIPTION
## Summary
- compute aggregated mean metrics across all processed NIfTI pairs
- print the summary metrics to stdout alongside per-file metrics
- append the summary row to the generated CSV report

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6224fb00883328d5351e967288f14