### PR TITLE
Restore original scaling when exporting validation outputs

### DIFF
--- a/main.py
+++ b/main.py
@@ -214,6 +214,9 @@ def main() -> None:
             ssim_mask_threshold=cfg.ssim_mask_threshold,
             ssim_mask_dilation=cfg.ssim_mask_dilation,
             use_tqdm=cfg.use_tqdm,
+            normalize_targets=cfg.normalize_targets,
+            img_min=cfg.img_min,
+            img_max=cfg.img_max,
         )
 
         scheduler.step()


### PR DESCRIPTION
## Summary
- propagate the target normalization settings into the validation routine
- denormalize predictions and targets before writing validation NIfTI artifacts

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e661553b988332abc8fb3e97ee8584